### PR TITLE
Implement role for exposing NVMe device files via symbolic link using AWS block device names

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An [Ansible Galaxy](https://galaxy.ansible.com/) role for creating device files 
 
 ## Requirements
 
-*None*
+* Python 2.7
 
 ## Role Variables
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,16 @@
-# Ansible Role: AWS NVMe Device Files
+# Ansible Role: AWS NVMe Device Files
 
 An [Ansible Galaxy](https://galaxy.ansible.com/) role for creating device files using AWS block device names for NVMe devices and partitions.
 
-# Requirements
+## Requirements
 
 *None*
 
-Role Variables
---------------
+## Role Variables
 
 *None*
 
-# Example Requirements File
+## Example Requirements File
 
 ```yml
 - src: https://github.com/companieshouse/ansible-role-aws-nvme-device-files
@@ -19,7 +18,7 @@ Role Variables
 ```
 
 
-# Example Playbook
+## Example Playbook
 
 Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
 
@@ -29,6 +28,6 @@ Including an example of how to use your role (for instance, with variables passe
         - aws-nvme-device-files
 ```
 
-# License
+## License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ An [Ansible Galaxy](https://galaxy.ansible.com/) role for creating device files 
   name: aws-nvme-device-files
 ```
 
-
 ## Example Playbook
 
 ```yml

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ An [Ansible Galaxy](https://galaxy.ansible.com/) role for creating device files 
 ```yml
 - src: https://github.com/companieshouse/ansible-role-aws-nvme-device-files
   name: aws-nvme-device-files
+  version: "n.n.n"
 ```
 
 ## Example Playbook

--- a/README.md
+++ b/README.md
@@ -1,1 +1,34 @@
-# ansible-role-aws-nvme-device-files
+# Ansible Role: AWS NVMe Device Files
+
+An [Ansible Galaxy](https://galaxy.ansible.com/) role for creating device files using AWS block device names for NVMe devices and partitions.
+
+# Requirements
+
+*None*
+
+Role Variables
+--------------
+
+*None*
+
+# Example Requirements File
+
+```yml
+- src: https://github.com/companieshouse/ansible-role-aws-nvme-device-files
+  name: aws-nvme-device-files
+```
+
+
+# Example Playbook
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+
+```yml
+    - hosts: servers
+      roles:
+        - aws-nvme-device-files
+```
+
+# License
+
+MIT

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ An [Ansible Galaxy](https://galaxy.ansible.com/) role for creating device files 
 
 *None*
 
-## Example Requirements File
+## Example Requirements File
 
 ```yml
 - src: https://github.com/companieshouse/ansible-role-aws-nvme-device-files

--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ An [Ansible Galaxy](https://galaxy.ansible.com/) role for creating device files 
 
 ## Example Playbook
 
-Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
-
 ```yml
     - hosts: servers
       roles:

--- a/files/70-ec2-nvme-devices.rules
+++ b/files/70-ec2-nvme-devices.rules
@@ -1,0 +1,18 @@
+# Copyright 2006 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+#
+# Licensed under the MIT License. See the LICENSE accompanying this file
+# for the specific language governing permissions and limitations under
+# the License.
+
+#nvme-ns-* devices
+KERNEL=="nvme[0-9]*n[0-9]*", ENV{DEVTYPE}=="disk", ATTRS{serial}=="?*", ATTRS{model}=="?*", SYMLINK+="disk/by-id/nvme-$attr{model}_$attr{serial}-ns-%n", OPTIONS+="string_escape=replace"
+
+#nvme partitions
+KERNEL=="nvme[0-9]*n[0-9]*p[0-9]*", ENV{DEVTYPE}=="partition", ATTRS{serial}=="?*", ATTRS{model}=="?*",  IMPORT{program}="ec2nvme-nsid %k"
+KERNEL=="nvme[0-9]*n[0-9]*p[0-9]*", ENV{DEVTYPE}=="partition", ATTRS{serial}=="?*", ATTRS{model}=="?*",  ENV{_NS_ID}=="?*", SYMLINK+="disk/by-id/nvme-$attr{model}_$attr{serial}-ns-$env{_NS_ID}-part%n", OPTIONS+="string_escape=replace"
+
+# ebs nvme devices
+KERNEL=="nvme[0-9]*n[0-9]*",        ENV{DEVTYPE}=="disk",      ATTRS{model}=="Amazon Elastic Block Store", PROGRAM="/sbin/ebsnvme-id -u /dev/%k", SYMLINK+="%c"
+KERNEL=="nvme[0-9]*n[0-9]*p[0-9]*", ENV{DEVTYPE}=="partition", ATTRS{model}=="Amazon Elastic Block Store", PROGRAM="/sbin/ebsnvme-id -u /dev/%k", SYMLINK+="%c%n"
+# instance store nvme devices
+KERNEL=="nvme[0-9]*n[0-9]*",        ENV{DEVTYPE}=="disk",      ATTRS{model}=="Amazon EC2 NVMe Instance Storage", ATTR{queue/io_timeout}="90000"

--- a/files/ebsnvme-id
+++ b/files/ebsnvme-id
@@ -1,0 +1,164 @@
+#!/usr/bin/env python2.7
+
+# Copyright 2017 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+#
+# Licensed under the MIT License. See the LICENSE accompanying this file
+# for the specific language governing permissions and limitations under
+# the License.
+
+"""
+Usage:
+Read EBS device information and provide information about
+the volume.
+"""
+
+import argparse
+from ctypes import *
+from fcntl import ioctl
+import sys
+
+NVME_ADMIN_IDENTIFY = 0x06
+NVME_IOCTL_ADMIN_CMD = 0xC0484E41
+AMZN_NVME_VID = 0x1D0F
+AMZN_NVME_EBS_MN = "Amazon Elastic Block Store"
+
+class nvme_admin_command(Structure):
+    _pack_ = 1
+    _fields_ = [("opcode", c_uint8),      # op code
+                ("flags", c_uint8),       # fused operation
+                ("cid", c_uint16),        # command id
+                ("nsid", c_uint32),       # namespace id
+                ("reserved0", c_uint64),
+                ("mptr", c_uint64),       # metadata pointer
+                ("addr", c_uint64),       # data pointer
+                ("mlen", c_uint32),       # metadata length
+                ("alen", c_uint32),       # data length
+                ("cdw10", c_uint32),
+                ("cdw11", c_uint32),
+                ("cdw12", c_uint32),
+                ("cdw13", c_uint32),
+                ("cdw14", c_uint32),
+                ("cdw15", c_uint32),
+                ("reserved1", c_uint64)]
+
+class nvme_identify_controller_amzn_vs(Structure):
+    _pack_ = 1
+    _fields_ = [("bdev", c_char * 32),  # block device name
+                ("reserved0", c_char * (1024 - 32))]
+
+class nvme_identify_controller_psd(Structure):
+    _pack_ = 1
+    _fields_ = [("mp", c_uint16),       # maximum power
+                ("reserved0", c_uint16),
+                ("enlat", c_uint32),     # entry latency
+                ("exlat", c_uint32),     # exit latency
+                ("rrt", c_uint8),       # relative read throughput
+                ("rrl", c_uint8),       # relative read latency
+                ("rwt", c_uint8),       # relative write throughput
+                ("rwl", c_uint8),       # relative write latency
+                ("reserved1", c_char * 16)]
+
+class nvme_identify_controller(Structure):
+    _pack_ = 1
+    _fields_ = [("vid", c_uint16),          # PCI Vendor ID
+                ("ssvid", c_uint16),        # PCI Subsystem Vendor ID
+                ("sn", c_char * 20),        # Serial Number
+                ("mn", c_char * 40),        # Module Number
+                ("fr", c_char * 8),         # Firmware Revision
+                ("rab", c_uint8),           # Recommend Arbitration Burst
+                ("ieee", c_uint8 * 3),      # IEEE OUI Identifier
+                ("mic", c_uint8),           # Multi-Interface Capabilities
+                ("mdts", c_uint8),          # Maximum Data Transfer Size
+                ("reserved0", c_uint8 * (256 - 78)),
+                ("oacs", c_uint16),         # Optional Admin Command Support
+                ("acl", c_uint8),           # Abort Command Limit
+                ("aerl", c_uint8),          # Asynchronous Event Request Limit
+                ("frmw", c_uint8),          # Firmware Updates
+                ("lpa", c_uint8),           # Log Page Attributes
+                ("elpe", c_uint8),          # Error Log Page Entries
+                ("npss", c_uint8),          # Number of Power States Support
+                ("avscc", c_uint8),         # Admin Vendor Specific Command Configuration
+                ("reserved1", c_uint8 * (512 - 265)),
+                ("sqes", c_uint8),          # Submission Queue Entry Size
+                ("cqes", c_uint8),          # Completion Queue Entry Size
+                ("reserved2", c_uint16),
+                ("nn", c_uint32),            # Number of Namespaces
+                ("oncs", c_uint16),         # Optional NVM Command Support
+                ("fuses", c_uint16),        # Fused Operation Support
+                ("fna", c_uint8),           # Format NVM Attributes
+                ("vwc", c_uint8),           # Volatile Write Cache
+                ("awun", c_uint16),         # Atomic Write Unit Normal
+                ("awupf", c_uint16),        # Atomic Write Unit Power Fail
+                ("nvscc", c_uint8),         # NVM Vendor Specific Command Configuration
+                ("reserved3", c_uint8 * (704 - 531)),
+                ("reserved4", c_uint8 * (2048 - 704)),
+                ("psd", nvme_identify_controller_psd * 32),     # Power State Descriptor
+                ("vs", nvme_identify_controller_amzn_vs)]  # Vendor Specific
+
+class ebs_nvme_device:
+    def __init__(self, device):
+        self.device = device
+        self.ctrl_identify()
+
+    def _nvme_ioctl(self, id_response, id_len):
+        admin_cmd = nvme_admin_command(opcode = NVME_ADMIN_IDENTIFY,
+                                       addr = id_response,
+                                       alen = id_len,
+                                       cdw10 = 1)
+
+        with open(self.device, "rw") as nvme:
+            ioctl(nvme, NVME_IOCTL_ADMIN_CMD, admin_cmd)
+
+    def ctrl_identify(self):
+        self.id_ctrl = nvme_identify_controller()
+        self._nvme_ioctl(addressof(self.id_ctrl), sizeof(self.id_ctrl))
+
+        if self.id_ctrl.vid != AMZN_NVME_VID or self.id_ctrl.mn.strip() != AMZN_NVME_EBS_MN:
+            raise TypeError("[ERROR] Not an EBS device: '{0}'".format(self.device))
+
+    def get_volume_id(self):
+        vol = self.id_ctrl.sn
+
+        if vol.startswith("vol") and vol[3] != "-":
+            vol = "vol-" + vol[3:]
+
+        return vol
+
+    def get_block_device(self, stripped=False):
+        dev = self.id_ctrl.vs.bdev.strip()
+
+        if stripped and dev.startswith("/dev/"):
+            dev = dev[5:]
+
+        return dev
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Reads EBS information from NVMe devices.")
+    parser.add_argument("device", nargs=1, help="Device to query")
+
+    display = parser.add_argument_group("Display Options")
+    display.add_argument("-v", "--volume", action="store_true",
+            help="Return volume-id")
+    display.add_argument("-b", "--block-dev", action="store_true",
+            help="Return block device mapping")
+    display.add_argument("-u", "--udev", action="store_true",
+            help="Output data in format suitable for udev rules")
+
+    if len(sys.argv) < 2:
+        parser.print_help()
+        sys.exit(1)
+
+    args = parser.parse_args()
+
+    get_all = not (args.udev or args.volume or args.block_dev)
+
+    try:
+        dev = ebs_nvme_device(args.device[0])
+    except (IOError, TypeError) as err:
+        print >> sys.stderr, err
+        sys.exit(1)
+
+    if get_all or args.volume:
+        print "Volume ID: {0}".format(dev.get_volume_id())
+    if get_all or args.block_dev or args.udev:
+        print dev.get_block_device(args.udev)

--- a/files/ec2nvme-nsid
+++ b/files/ec2nvme-nsid
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Copyright 2016 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+#
+# Licensed under the MIT License. See the LICENSE accompanying this file
+# for the specific language governing permissions and limitations under
+# the License.
+
+#Expected input if partition's kernel name like nvme0n1p2
+if [ $# -eq 0 ] ; then
+  exit 1
+else
+  # extract ns id from partition's kernel name and export it
+  NSID=$(echo -n "$@" | cut -f 3 -d 'n' | cut -f 1 -d 'p')
+  echo "_NS_ID=${NSID}"
+fi

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+
+- name: Replay kernel device events
+  command:
+    cmd: udevadm trigger --type=devices

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,14 @@
+dependencies: []
+
+galaxy_info:
+  author: Companies House
+  description: Expose NVME volumes via symbolic link device files with AWS block device names
+  license: MIT
+  min_ansible_version: 2.9.10
+  platforms:
+    - name: centos
+      versions:
+        - 7
+  galaxy_tags:
+    - aws
+    - nvme

--- a/tasks/check.yml
+++ b/tasks/check.yml
@@ -1,0 +1,10 @@
+---
+
+- name: Check for presence of Python 2.7 interpreter
+  shell: "which python2.7"
+  register: python
+  ignore_errors: true
+
+- fail:
+    msg: "Python 2.7 interpreter not found"
+  when: python.rc != 0

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -29,3 +29,6 @@
     mode: '0755'
   notify:
     - Replay kernel device events
+
+- name: Ensure symbolic links are created for connected devices
+  meta: flush_handlers

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -7,6 +7,8 @@
     owner: root
     group: root
     mode: '0644'
+  notify:
+    - Replay kernel device events
 
 - name: Install NVME namespace identifier script
   copy:
@@ -15,6 +17,8 @@
     owner: root
     group: root
     mode: '0755'
+  notify:
+    - Replay kernel device events
 
 - name: Install NVME device identifier script
   copy:
@@ -23,3 +27,5 @@
     owner: root
     group: root
     mode: '0755'
+  notify:
+    - Replay kernel device events

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,0 +1,25 @@
+---
+
+- name: Install udev rules for persistent block device names
+  copy:
+    src: "{{ role_path }}/files/70-ec2-nvme-devices.rules"
+    dest: /etc/udev/rules.d
+    owner: root
+    group: root
+    mode: '0644'
+
+- name: Install NVME namespace identifier script
+  copy:
+    src: "{{ role_path }}/files/ec2nvme-nsid"
+    dest: /usr/lib/udev
+    owner: root
+    group: root
+    mode: '0755'
+
+- name: Install NVME device identifier script
+  copy:
+    src: "{{ role_path }}/files/ebsnvme-id"
+    dest: /sbin
+    owner: root
+    group: root
+    mode: '0755'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+
+- include_tasks: install.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,3 +1,4 @@
 ---
 
+- include_tasks: check.yml
 - include_tasks: install.yml


### PR DESCRIPTION
EBS volumes are exposed as NVMe block devices on instances that are built on the [Nitro](https://aws.amazon.com/ec2/nitro/) system. 

The device names specified in the Amazon EC2 console (or via infrastructure code) when attaching an EBS volume are renamed using NVMe device names (e.g. `/dev/nvme[0-26]n1`), and the original device name is captured in the vendor-specific data field of the NVMe controller identification. The block device driver may assign NVMe device names out of order from those specified in the block device mappings. This makes the original block device mapping name unusable from the perspective of provisioning scripts when using Nitro-based instance types for AMI build (e.g. `t3`).

This pull-request introduces an Ansible Galaxy role that exposes symbolic link device files that match the original block device mapping names for any NVMe namespace, device, or partition, and uses a combination of event-driven `udev` rules and scripts to extract the device name from the vendor-specific data field to ensure persistent block device names.

ℹ️ Centos  8 support will be added in a future update, along with Python 3 support. This initial implementation is targeted at CentOS 7 and Python 2.7 for a specific use case.